### PR TITLE
fix: resolve MIME type mismatch in image rendering

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervina-labs/dob-render",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "RGB++ DOB render SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/render-image-svg.ts
+++ b/packages/sdk/src/render-image-svg.ts
@@ -1,8 +1,9 @@
 import satori from 'satori'
 import type { ParsedTrait } from './traits-parser'
 import { config } from './config'
-import {hexToBase64, isBtcFs, isIpfs} from './utils/string'
 import { backgroundColorParser } from './background-color-parser'
+import { processFileServerResult } from './utils/mime'
+import { isBtcFs, isIpfs } from './utils/string'
 
 export async function renderImageSvg(traits: ParsedTrait[]): Promise<string> {
   const prevBg = traits.find((trait) => trait.name === 'prev.bg')
@@ -12,10 +13,10 @@ export async function renderImageSvg(traits: ParsedTrait[]): Promise<string> {
   if (prevBg?.value && typeof prevBg.value === 'string') {
     if (isBtcFs(prevBg.value)) {
       const btcFsResult = await config.queryBtcFsFn(prevBg.value)
-      bgImage = typeof btcFsResult === 'string' ? btcFsResult : `data:${btcFsResult.content_type};base64,${hexToBase64(btcFsResult.content)}`
+      bgImage = processFileServerResult(btcFsResult)
     } else if (isIpfs(prevBg.value)) {
       const ipfsFsResult = await config.queryIpfsFn(prevBg.value)
-      bgImage = typeof ipfsFsResult === 'string' ? ipfsFsResult : `data:${ipfsFsResult.content_type};base64,${hexToBase64(ipfsFsResult.content)}`
+      bgImage = processFileServerResult(ipfsFsResult)
     } else if (prevBg.value.startsWith('https://')) {
       bgImage = prevBg.value
     }

--- a/packages/sdk/src/resolve-svg-traits.ts
+++ b/packages/sdk/src/resolve-svg-traits.ts
@@ -2,7 +2,7 @@ import type { INode } from 'svgson'
 import { parse } from 'svgson'
 import type { BtcFsURI, IpfsURI } from './config'
 import { config } from './config'
-import { hexToBase64 } from './utils/string'
+import { processFileServerResult } from './utils/mime'
 
 async function handleNodeHref(node: INode) {
   if (node.name !== 'image') {
@@ -15,25 +15,17 @@ async function handleNodeHref(node: INode) {
   }
   if ('href' in node.attributes) {
     const href = node.attributes.href
+    let result;
+    
     if (href.startsWith('btcfs://')) {
-      const result = await config.queryBtcFsFn(node.attributes.href as BtcFsURI)
-      node.attributes.href =
-        typeof result === 'string'
-          ? result
-          : `data:${result.content_type};base64,${hexToBase64(result.content)}`
+      result = await config.queryBtcFsFn(node.attributes.href as BtcFsURI)
     } else if (href.startsWith('ipfs://')) {
-      const result = await config.queryIpfsFn(node.attributes.href as IpfsURI)
-      node.attributes.href =
-        typeof result === 'string'
-          ? result
-          : `data:${result.content_type};base64,${hexToBase64(result.content)}`
+      result = await config.queryIpfsFn(node.attributes.href as IpfsURI)
     } else {
-      const result = await config.queryUrlFn(node.attributes.href as string)
-      node.attributes.href =
-        typeof result === 'string'
-          ? result
-          : `data:${result.content_type};base64,${hexToBase64(result.content)}`
+      result = await config.queryUrlFn(node.attributes.href as string)
     }
+    
+    node.attributes.href = processFileServerResult(result)
   }
 
   return node

--- a/packages/sdk/src/utils/mime.ts
+++ b/packages/sdk/src/utils/mime.ts
@@ -1,0 +1,87 @@
+import type { FileServerResult } from '../config'
+import { hexToBase64 } from './string'
+
+/**
+ * Detects the MIME type of an image from its hex-encoded content by examining file signatures
+ * @param hexstring Hex-encoded image content
+ * @returns The detected MIME type or null if not recognized
+ */
+export function detectImageMimeType(hexstring: string): string | null {
+  // Skip if string is too short to contain a signature
+  if (!hexstring || hexstring.length < 8) {
+    return null
+  }
+
+  // Convert to lowercase for consistent comparison
+  const hex = hexstring.toLowerCase()
+  
+  // JPEG: starts with ffd8ff
+  if (hex.startsWith('ffd8ff')) {
+    return 'image/jpeg'
+  }
+  
+  // PNG: starts with 89504e47 (‰PNG)
+  if (hex.startsWith('89504e47')) {
+    return 'image/png'
+  }
+  
+  // GIF: starts with 474946 (GIF)
+  if (hex.startsWith('474946')) {
+    return 'image/gif'
+  }
+  
+  // WebP: RIFF....WEBP
+  if (hex.startsWith('52494646') && hex.substring(16, 24) === '57454250') {
+    return 'image/webp'
+  }
+  
+  // BMP: starts with 424d (BM)
+  if (hex.startsWith('424d')) {
+    return 'image/bmp'
+  }
+  
+  // SVG: might start with XML declaration or svg tag
+  // This is a rough check since SVG is text-based
+  if (hex.includes('3c737667') || hex.includes('3c3f786d6c')) { // <svg or <?xml
+    return 'image/svg+xml'
+  }
+  
+  // TIFF: starts with 49492a00 (Intel) or 4d4d002a (Motorola)
+  if (hex.startsWith('49492a00') || hex.startsWith('4d4d002a')) {
+    return 'image/tiff'
+  }
+  
+  // AVIF: ftyp....avif
+  if (hex.includes('66747970') && hex.includes('61766966')) {
+    return 'image/avif'
+  }
+  
+  // ICO: starts with 00000100
+  if (hex.startsWith('00000100')) {
+    return 'image/x-icon'
+  }
+  
+  return null
+}
+
+/**
+ * Process file server result and convert to data URL with correct MIME type
+ * @param result Result from file server
+ * @returns Data URL or original string
+ */
+export function processFileServerResult(result: FileServerResult): string {
+  if (typeof result === 'string') {
+    return result
+  }
+  
+  // Check if content_type is not an image type and try to detect the actual image type
+  let contentType = result.content_type
+  if (!contentType.startsWith('image/') && result.content) {
+    const mimeType = detectImageMimeType(result.content)
+    if (mimeType) {
+      contentType = mimeType
+    }
+  }
+  
+  return `data:${contentType};base64,${hexToBase64(result.content)}`
+}

--- a/packages/sdk/src/utils/mime.ts
+++ b/packages/sdk/src/utils/mime.ts
@@ -3,62 +3,62 @@ import { hexToBase64 } from './string'
 
 /**
  * Detects the MIME type of an image from its hex-encoded content by examining file signatures
- * @param hexstring Hex-encoded image content
+ * @param hexContent Hex-encoded image content
  * @returns The detected MIME type or null if not recognized
  */
-export function detectImageMimeType(hexstring: string): string | null {
-  // Skip if string is too short to contain a signature
-  if (!hexstring || hexstring.length < 8) {
+export function detectImageMimeType(hexContent: string): string | null {
+  // Skip if string is too short to contain a signature and content
+  if (!hexContent || hexContent.length < 64) {
     return null
   }
 
-  // Convert to lowercase for consistent comparison
-  const hex = hexstring.toLowerCase()
+  // Extract just the file header (first 32 bytes should be enough for most formats)
+  // and convert to lowercase for consistent comparison
+  const header = hexContent.substring(0, 64).toLowerCase() // 32 bytes = 64 hex chars
   
   // JPEG: starts with ffd8ff
-  if (hex.startsWith('ffd8ff')) {
+  if (header.startsWith('ffd8ff')) {
     return 'image/jpeg'
   }
   
   // PNG: starts with 89504e47 (‰PNG)
-  if (hex.startsWith('89504e47')) {
+  if (header.startsWith('89504e47')) {
     return 'image/png'
   }
   
   // GIF: starts with 474946 (GIF)
-  if (hex.startsWith('474946')) {
+  if (header.startsWith('474946')) {
     return 'image/gif'
   }
   
   // WebP: RIFF....WEBP
-  if (hex.startsWith('52494646') && hex.substring(16, 24) === '57454250') {
+  if (header.startsWith('52494646') && header.substring(16, 24) === '57454250') {
     return 'image/webp'
   }
   
   // BMP: starts with 424d (BM)
-  if (hex.startsWith('424d')) {
+  if (header.startsWith('424d')) {
     return 'image/bmp'
   }
-  
-  // SVG: might start with XML declaration or svg tag
-  // This is a rough check since SVG is text-based
-  if (hex.includes('3c737667') || hex.includes('3c3f786d6c')) { // <svg or <?xml
+
+  // SVG: starts with <svg or <?xml
+  if (header.startsWith('3c737667') || header.startsWith('3c3f786d6c')) {
     return 'image/svg+xml'
   }
   
   // TIFF: starts with 49492a00 (Intel) or 4d4d002a (Motorola)
-  if (hex.startsWith('49492a00') || hex.startsWith('4d4d002a')) {
+  if (header.startsWith('49492a00') || header.startsWith('4d4d002a')) {
     return 'image/tiff'
   }
   
-  // AVIF: ftyp....avif
-  if (hex.includes('66747970') && hex.includes('61766966')) {
-    return 'image/avif'
-  }
-  
   // ICO: starts with 00000100
-  if (hex.startsWith('00000100')) {
+  if (header.startsWith('00000100')) {
     return 'image/x-icon'
+  }
+
+  // AVIF: ftyp....avif
+  if (header.includes('66747970') && header.includes('61766966')) {
+    return 'image/avif'
   }
   
   return null

--- a/packages/sdk/src/utils/string.ts
+++ b/packages/sdk/src/utils/string.ts
@@ -1,4 +1,4 @@
-import type {BtcFsURI, IpfsURI} from '../config'
+import type {BtcFsURI, FileServerResult, IpfsURI} from '../config'
 
 export function parseStringToArray(str: string): string[] {
   const regex = /'([^']*)'/g

--- a/packages/sdk/src/utils/string.ts
+++ b/packages/sdk/src/utils/string.ts
@@ -1,4 +1,4 @@
-import type {BtcFsURI, FileServerResult, IpfsURI} from '../config'
+import type {BtcFsURI, IpfsURI} from '../config'
 
 export function parseStringToArray(str: string): string[] {
   const regex = /'([^']*)'/g


### PR DESCRIPTION
- Fix issue where queryBtcFsFn and queryIpfsFn return incorrect content_type (application/octet-stream) for image content
- Add detectImageMimeType utility to identify actual image type from hex content
- Extract processFileServerResult to handle MIME type detection for all non-image content types
- Move image processing utilities to dedicated mime.ts module
- Apply fix to both renderImageSvg and handleNodeHref functions
- Bump version to 0.2.5

### Before fixed:
https://explorer.nervos.org/nft-info/0x52e5418248a2e3125f411670edb8633acc9a4e0d680941270c42d6fb89ef8002/0xeed9a6d4a0648971e986cfc7a3cfdc02f1bd300632903794235ce9dcc3cabe59

### After fixed:

https://dob-render.vercel.app/?is_mainnet=true&token_key=eed9a6d4a0648971e986cfc7a3cfdc02f1bd300632903794235ce9dcc3cabe59
